### PR TITLE
Ajax sandbox

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
             </div>
           </article>
           <article id="inspect-map"></article>
-          <button id=view-history><a href="/history">View Full Inspection History</a></button>
+          <button id="view-history">View Full Inspection History</button>
       </section>
     </script>
     <!-- inspection history handlebars template -->

--- a/scripts/history.js
+++ b/scripts/history.js
@@ -2,16 +2,12 @@
   var historyInit = {};
   historyInit.all = [];
 
-  historyInit.requestHistoryData = function(userInput) {
-    $.get('/data/resource/gkhn-e8mn.json?$select=name,inspection_date,inspection_score,address,inspection_result,zip_code,city,inspection_closed_business,violation_type,violation_description,longitude,latitude&$order=inspection_date%20DESC&inspection_type=Routine%20Inspection/Field%20Review&$q=' + userInput)
-    .done(function(data, message, xhr) {
-      historyInit.all = data;
-      
-      $('#inspection-history table tbody').empty();
-      historyInit.all.forEach(function(current) {
-        current.inspection_date = current.inspection_date.substring(0, 10);
-        $('#inspection-history table tbody').append(historyView.displayHistoryRow(current));
-      });
+  historyInit.requestHistoryData = function() {
+    $('#inspection-history table tbody').empty();
+
+    historyInit.all.forEach(function(current) {
+      current.inspection_date = current.inspection_date.substring(0, 10);
+      $('#inspection-history table tbody').append(historyView.displayHistoryRow(current));
     });
   };
 

--- a/scripts/historyController.js
+++ b/scripts/historyController.js
@@ -2,8 +2,12 @@
   var historyController = {};
 
   historyController.index = function() {
-    $('#inspection-history').toggle();
+    $('main').on('click', '#view-history', function() {
+      $('#inspection-history').toggle();
+      historyInit.requestHistoryData();
+    });
   };
+  historyController.index();
 
   module.historyController = historyController;
 })(window);

--- a/scripts/inspection.js
+++ b/scripts/inspection.js
@@ -65,28 +65,27 @@
       $('#search-input').val('');
     }
     else {
-      $.get('/data/resource/gkhn-e8mn.json?$select=name,inspection_date,inspection_score,address,city,zip_code,phone,latitude,longitude&$order=inspection_date%20DESC&inspection_type=Routine%20Inspection/Field%20Review&$q=' + place + '&$limit=1')
+      $.get('/data/resource/gkhn-e8mn.json?$select=name,inspection_date,inspection_score,address,city,zip_code,phone,latitude,longitude,violation_description&$order=inspection_date%20DESC&inspection_type=Routine%20Inspection/Field%20Review&$q=' + place)
       .done(function(data, message, xhr) {
         if (xhr.responseJSON.length === 0) {
           alert('No Inspection Data Available.');
           $('#search-input').val('');
         }
         else {
-          Inspection.current = data;
-          Inspection.current.forEach(function(item) {
-            var total = new Inspection(item);
-            total.inspection_date = total.inspection_date.substring(0, 10);
-            //store search into database
-            total.insertData();
-          });
+          historyInit.all = data;
+
+          Inspection.current = new Inspection(data[0]);
+          Inspection.current.inspection_date = Inspection.current.inspection_date.substring(0, 10);
+          //store search into database
+          Inspection.current.insertData();
 
           $('#report-card').empty()
-          .append(inspectionView.displayResults(Inspection.current[0]))
+          .append(inspectionView.displayResults(Inspection.current))
           .show().siblings().hide();
 
-          inspectionView.filterResults(Inspection.current[0]);
-          mapView.updateMap();
-          history.pushState(null, null, '../reportcard/' + place);
+          inspectionView.filterResults(Inspection.current);
+          mapView.updateMap(Inspection.current);
+          history.replaceState(null, null, '../reportcard/' + place);
           $('#search-input').val('');
           callback();
         }
@@ -95,9 +94,7 @@
   };
 
   Inspection.with = function(attr) {
-    return Inspection.current.filter(function(inspection) {
-      return inspection[attr];
-    });
+    return Inspection.current[attr];
   };
 
   Inspection.createTable();

--- a/scripts/inspection.js
+++ b/scripts/inspection.js
@@ -85,7 +85,7 @@
 
           inspectionView.filterResults(Inspection.current);
           mapView.updateMap(Inspection.current);
-          history.replaceState(null, null, '../reportcard/' + place);
+          history.pushState(null, null, '../reportcard/' + place);
           $('#search-input').val('');
           callback();
         }

--- a/scripts/inspection.js
+++ b/scripts/inspection.js
@@ -25,6 +25,15 @@
     );
   };
 
+  Inspection.inputOptions = function() {
+    $('#search-input').autocomplete(
+      {
+        source: Inspection.names,
+        minLength: 3
+      }
+    );
+  };
+
   Inspection.buildNames = function(callback) {
     $.get('/data/resource/gkhn-e8mn.json?$select=name&$group=name&$order=name&$limit=50000')
     .done(function(data, message, xhr) {
@@ -91,14 +100,8 @@
     });
   };
 
-  Inspection.inputOptions = function() {
-    $('#search-input').autocomplete(
-      {
-        source: Inspection.names,
-        minLength: 3
-      }
-    );
-  };
+  Inspection.createTable();
+  Inspection.buildNames(Inspection.inputOptions);
 
   module.Inspection = Inspection;
 })(window);

--- a/scripts/inspectionController.js
+++ b/scripts/inspectionController.js
@@ -4,8 +4,6 @@
   inspectionController.index = function() {
     $('main').children().hide();
 
-    Inspection.createTable();
-
     $('.restaurant-search').on('submit', function(event) {
       event.preventDefault();
       var restName = $('#search-input').val();
@@ -15,7 +13,6 @@
       historyInit.requestHistoryData(restName);
     });
 
-    Inspection.buildNames(Inspection.inputOptions);
     $('#search-input').focus();
   };
 

--- a/scripts/inspectionController.js
+++ b/scripts/inspectionController.js
@@ -3,18 +3,19 @@
 
   inspectionController.index = function() {
     $('main').children().hide();
+    $('#search-input').focus();
+  };
 
+  inspectionController.search = function(){
     $('.restaurant-search').on('submit', function(event) {
       event.preventDefault();
       var restName = $('#search-input').val();
       restName = restName.replace(/[^\w\s]/gi, '+');
 
       Inspection.requestInspectionData(restName, Inspection.with);
-      historyInit.requestHistoryData(restName);
     });
-
-    $('#search-input').focus();
   };
+  inspectionController.search();
 
   module.inspectionController = inspectionController;
 })(window);

--- a/scripts/mapView.js
+++ b/scripts/mapView.js
@@ -1,11 +1,11 @@
 (function(module) {
   var mapView = {};
 
-  mapView.updateMap = function() {
+  mapView.updateMap = function(current) {
     $('#inspect-map').show();
     mapInspection.initMap();
 
-    var inspectionLatLong = {lat: parseFloat(Inspection.current[0].latitude), lng: parseFloat(Inspection.current[0].longitude)};
+    var inspectionLatLong = {lat: parseFloat(current.latitude), lng: parseFloat(current.longitude)};
     mapInspection.map.setCenter(inspectionLatLong);
     mapInspection.map.setZoom(17);
 
@@ -13,7 +13,7 @@
       {
         position: inspectionLatLong,
         map: mapInspection.map,
-        title: Inspection.current[0].name
+        title: current.name
       }
     );
   };

--- a/scripts/reportcardController.js
+++ b/scripts/reportcardController.js
@@ -7,5 +7,6 @@
 
     historyInit.requestHistoryData(ctx.params.establishment);
   };
+  
   module.reportcardController = reportcardController;
 })(window);

--- a/scripts/routes.js
+++ b/scripts/routes.js
@@ -1,6 +1,6 @@
 page('/', inspectionController.index);
 
-page('/history', historyController.index);
+// page('/history', historyController.index);
 
 page('/about', aboutController.index);
 
@@ -9,5 +9,7 @@ page('/contact', contactController.index);
 page('/project', projectController.index);
 
 page('/reportcard/:establishment', reportcardController.index);
+
+page('*', '/');
 
 page();

--- a/scripts/routes.js
+++ b/scripts/routes.js
@@ -1,7 +1,5 @@
 page('/', inspectionController.index);
 
-// page('/history', historyController.index);
-
 page('/about', aboutController.index);
 
 page('/contact', contactController.index);


### PR DESCRIPTION
- index.html - Removed history link/route.  Going to the /history url opened up an broken page.  It is now obsolete with the new direct report card links
- history.js - Removed second ajax call for history (historyInit.all results are now loaded in main ajax call)
- historyController.js - Hooked up a new event to toggle history on click of button (due to depreciation of history route)
- inspection.js - Slightly varied ajax call to handle history information.  Adjusted loading of data arrays and database.  Pulled the two initialization functions (buildNames, createTable) out of the inspectionController so they only run on page load, not after every search.
- inspectionController.js - Removed intialization functions from search controller.  Moved event handler out of main controller to avoid the attachment of duplicate events (this is where all my wierd extra function calls were coming from)
- mapView.js - Modularized updateMap function
- routes.js - Removed history route, added default route to prevent erroneous routes from opening broken index pages
